### PR TITLE
Fix for build paths with spaces (might be macOS only)

### DIFF
--- a/OpenDSS.sublime-build
+++ b/OpenDSS.sublime-build
@@ -1,16 +1,5 @@
 {
   "selector": "source.opendss",
-  "variants":
-  [
-    {
-      "name": "Command line",
-      "cmd": ["opendsscmd", "\"$file\""],
-      "working_dir": "$file_path"
-    },
-    {
-      "name": "Run command line",
-      "cmd": ["build_command_line", "$file"],
-      "working_dir": "$file_path"
-    }
-  ]
+  "cmd": ["opendsscmd", "\"$file\""],
+  "working_dir": "$file_path"
 }

--- a/OpenDSS.sublime-build
+++ b/OpenDSS.sublime-build
@@ -1,16 +1,5 @@
 {
   "selector": "source.opendss",
-  "variants":
-  [
-    {
-      "name": "Command line",
-      "cmd": ["opendsscmd", "$file"],
-      "working_dir": "$file_path"
-    },
-    {
-      "name": "Run command line",
-      "cmd": ["build_command_line", "$file"],
-      "working_dir": "$file_path"
-    }
-  ]
+  "cmd": ["opendsscmd", "\"$file\""],
+  "working_dir": "$file_path"
 }

--- a/OpenDSS.sublime-build
+++ b/OpenDSS.sublime-build
@@ -1,5 +1,16 @@
 {
   "selector": "source.opendss",
-  "cmd": ["opendsscmd", "\"$file\""],
-  "working_dir": "$file_path"
+  "variants":
+  [
+    {
+      "name": "Command line",
+      "cmd": ["opendsscmd", "\"$file\""],
+      "working_dir": "$file_path"
+    },
+    {
+      "name": "Run command line",
+      "cmd": ["build_command_line", "$file"],
+      "working_dir": "$file_path"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 OpenDSS script file syntax definitions for Sublime Text 3.
 
+## Installation
+
+Place the full repository folder in your sublime user packages folder, which by default is at:
+
+- Linux: ~/.config/sublime-text-3/Packages/User/
+- macOs: ~/Library/Application Support/Sublime Text 3/Packages/User/
+- Windows: %APPDATA%\Sublime Text 3\User\
+
 ## Features
 
 - Comments and keywords syntax highlighting
+- Build system
 
-## Documentation
+## Credit
 
-https://github.com/dparrini/sublime_opendss
-
-## Support
-
-Feel free to report any bugs you find. You are welcome to fork and submit pull requests.
-
-## License
-
-The syntax definition is available at [GitHub](https://github.com/dparrini/sublime_opendss) under the MIT license.
+This repo contains only minor tweaks to dparrini's excellent original work from https://github.com/dparrini/sublime_opendss

--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 
 OpenDSS script file syntax definitions for Sublime Text 3.
 
-## Installation
-
-Place the full repository folder in your sublime user packages folder, which by default is at:
-
-- Linux: ~/.config/sublime-text-3/Packages/User/
-- macOs: ~/Library/Application Support/Sublime Text 3/Packages/User/
-- Windows: %APPDATA%\Sublime Text 3\User\
-
 ## Features
 
 - Comments and keywords syntax highlighting
-- Build system
 
-## Credit
+## Documentation
 
-This repo contains only minor tweaks to dparrini's excellent original work from https://github.com/dparrini/sublime_opendss
+https://github.com/dparrini/sublime_opendss
+
+## Support
+
+Feel free to report any bugs you find. You are welcome to fork and submit pull requests.
+
+## License
+
+The syntax definition is available at [GitHub](https://github.com/dparrini/sublime_opendss) under the MIT license.


### PR DESCRIPTION
Hi! Your sublime package for openDSS is awesome.

I noticed on macOS that if a build of a dss file is triggered and the full path for that file has spaces in it, opendss fails. Here in this pull request is a minor change that fixes the issue (quotes the path in the build command).

Thanks for all your hard work building this package.